### PR TITLE
Disable proxy lines in Dockerfile_genai

### DIFF
--- a/modules/ollama_openvino/Dockerfile_genai
+++ b/modules/ollama_openvino/Dockerfile_genai
@@ -2,10 +2,10 @@ FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-c"]
 
-ENV no_proxy=http://Child-mu.intel.com:912
-ENV ftp_proxy=http://Child-mu.intel.com:912
-ENV http_proxy=http://Child-mu.intel.com:912
-ENV https_proxy=http://Child-mu.intel.com:912
+#ENV no_proxy=http://Child-mu.intel.com:912
+#ENV ftp_proxy=http://Child-mu.intel.com:912
+#ENV http_proxy=http://Child-mu.intel.com:912
+#ENV https_proxy=http://Child-mu.intel.com:912
 
 RUN apt-get update && apt install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa \


### PR DESCRIPTION
I wasn't able to build `Dockerfile_genai` until I commented out the proxy lines - went smoothly after that